### PR TITLE
Add package checking logic

### DIFF
--- a/transcriptome_panel/server.R
+++ b/transcriptome_panel/server.R
@@ -1,6 +1,12 @@
 # source("https://bioconductor.org/biocLite.R")
 # biocLite("cummeRbund")
 # install.packages("shiny")
+
+#This logic reads the list of packages required and installs them if they are missing. Required admin rights.
+list_of_packages <- c("shiny")
+new_packages <- list_of_packages[!(list_of_packages %in% installed.packages()[,"Package"])]
+if(length(new_packages)) install.packages(new_packages)
+
 library(shiny)
 library(cummeRbund)
 


### PR DESCRIPTION
Add some code that will check the list of required packages (R packages
only, not bioconductor) and install any that are missing.

Requires admin rights to install packages (I think)
