### PR TITLE
Add package loading code

### DIFF
--- a/transcriptome_panel/server.R
+++ b/transcriptome_panel/server.R
@@ -7,7 +7,8 @@ list_of_packages <- c("shiny")
 new_packages <- list_of_packages[!(list_of_packages %in% installed.packages()[,"Package"])]
 if(length(new_packages)) install.packages(new_packages)
 
-library(shiny)
+invisible(lapply(list_of_packages, library, character.only = TRUE))
+
 library(cummeRbund)
 
 


### PR DESCRIPTION
Load all the packages you want without having to type library() for
each one.

Only doing it for R packages at the moment.
